### PR TITLE
use current gradle version. Fixes build exception in pactVerify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,5 +65,5 @@ project(':microservices-pact-provider') {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '1.12'
+    gradleVersion = '2.3'
 }


### PR DESCRIPTION
Fixes the following exception:
./gradlew pactVerify
FAILURE: Build failed with an exception.
Execution failed for task ':microservices-pact-provider:pactVerify_fooProvider'.
> You must specify the pactfile to execute (use pactFile = ...)